### PR TITLE
Add ProxyTCPClientHandler for TCP proxying in Modbus communication

### DIFF
--- a/proxyTCPClientHandler.go
+++ b/proxyTCPClientHandler.go
@@ -1,0 +1,230 @@
+package modbus
+
+import (
+	"io"
+	log "log/slog"
+	"net"
+	"strings"
+	"sync"
+	"time"
+)
+
+type ProxyTCPClientHandler struct {
+	TCPClientHandler
+	rtuPackager
+
+	// Proxy-specific fields
+	proxyTargetAddress string
+
+	// Connection management
+	mu           sync.Mutex
+	remoteConn   net.Conn
+	proxyRunning bool
+	stopChan     chan struct{}
+	wg           sync.WaitGroup
+	// Frame reassembly buffers
+	remoteBuffer []byte
+	localBuffer  []byte
+}
+
+func NewProxyTCPClientHandler(proxyTargetAddress string, localAddress string) *ProxyTCPClientHandler {
+	handler := &ProxyTCPClientHandler{
+		TCPClientHandler:   TCPClientHandler{},
+		proxyTargetAddress: proxyTargetAddress,
+		stopChan:           make(chan struct{}),
+	}
+	// Set the local address for the embedded TCPClientHandler
+	handler.TCPClientHandler.tcpTransporter.Address = localAddress
+	return handler
+}
+
+func (h *ProxyTCPClientHandler) Send(aduRequest []byte) (aduResponse []byte, err error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	// If proxy is not running, start it
+	if !h.proxyRunning {
+		if err = h.StartProxy(); err != nil {
+			return nil, err
+		}
+	}
+
+	// Use the standard TCP client handler to send to localhost:1502
+	return h.TCPClientHandler.Send(aduRequest)
+}
+
+func (h *ProxyTCPClientHandler) StartProxy() error {
+	// Connect to the remote target
+	remoteConn, err := net.Dial("tcp", h.proxyTargetAddress)
+	if err != nil {
+		return err
+	}
+	h.remoteConn = remoteConn
+
+	// Start the proxy forwarding goroutine
+	h.proxyRunning = true
+	h.wg.Add(1)
+	go h.runProxy()
+
+	return nil
+}
+
+func (h *ProxyTCPClientHandler) runProxy() {
+	defer h.wg.Done()
+	defer func() {
+		h.mu.Lock()
+		h.proxyRunning = false
+		if h.remoteConn != nil {
+			h.remoteConn.Close()
+			h.remoteConn = nil
+		}
+		h.mu.Unlock()
+	}()
+
+	// Get the local connection from the TCP client handler
+	h.mu.Lock()
+	localConn := h.TCPClientHandler.tcpTransporter.conn
+	h.mu.Unlock()
+
+	if localConn == nil {
+		return
+	}
+
+	// Create channels for coordination
+	done := make(chan struct{}, 2)
+
+	// Forward data from localhost:1502 to remote
+	h.wg.Add(1)
+	go func() {
+		defer h.wg.Done()
+		defer func() { done <- struct{}{} }()
+		h.forwardData(localConn, h.remoteConn, "local->remote")
+		//io.Copy(h.remoteConn, localConn)
+	}()
+
+	// Forward data from remote to localhost:1502
+	h.wg.Add(1)
+	go func() {
+		defer h.wg.Done()
+		defer func() { done <- struct{}{} }()
+		h.forwardData(h.remoteConn, localConn, "remote->local")
+		//io.Copy(localConn, h.remoteConn)
+	}()
+
+	// Wait for either direction to finish or stop signal
+	select {
+	case <-done:
+		// One direction finished, stop the other
+	case <-h.stopChan:
+		// Stop signal received
+	}
+}
+
+func (h *ProxyTCPClientHandler) Connect() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	// Connect to localhost:1502 using the standard TCP client handler
+	return h.TCPClientHandler.Connect()
+}
+
+func (h *ProxyTCPClientHandler) Close() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	// Stop the proxy
+	if h.proxyRunning {
+		close(h.stopChan)
+		h.proxyRunning = false
+
+		// Wait for proxy goroutines to finish
+		h.mu.Unlock()
+		h.wg.Wait()
+		h.mu.Lock()
+	}
+
+	// Close remote connection
+	if h.remoteConn != nil {
+		h.remoteConn.Close()
+		h.remoteConn = nil
+	}
+
+	// Close local connection
+	return h.TCPClientHandler.Close()
+}
+
+func (h *ProxyTCPClientHandler) forwardData(src, dst net.Conn, direction string) {
+
+	buffer := make([]byte, 4096)
+	var frameBuffer *[]byte
+
+	// Choose the appropriate buffer based on direction
+	if direction == "remote->local" {
+		frameBuffer = &h.remoteBuffer
+	} else {
+		frameBuffer = &h.localBuffer
+	}
+
+	for {
+		// Check for shutdown signal first
+		select {
+		case <-h.stopChan:
+			log.Info("Stopping TCP proxy", "direction", direction)
+			return
+		default:
+		}
+
+		// Set read deadline to allow periodic shutdown checks
+		src.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+
+		n, err := src.Read(buffer)
+		if err != nil {
+			// Check if it's a timeout error (expected for periodic doneCh checks)
+			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+				// Timeout is expected, continue to check doneCh
+				continue
+			}
+
+			// Check for "use of closed network connection" and similar connection errors. If so return
+			// by cleaning up
+			errStr := err.Error()
+			if strings.Contains(errStr, "use of closed network connection") ||
+				strings.Contains(errStr, "read: connection reset by peer") ||
+				strings.Contains(errStr, "broken pipe") {
+				log.Info("Connection closed by partner", "direction", direction, "error", err)
+				return
+			}
+
+			if err != io.EOF {
+				log.Error("Error reading data", "direction", direction, "error", err)
+
+			}
+			return
+		}
+
+		if n > 0 {
+			// Add to frame buffer
+			*frameBuffer = append(*frameBuffer, buffer[:n]...)
+
+			// Process complete frames
+			h.processFrames(frameBuffer, dst, direction)
+		}
+	}
+}
+
+func (h *ProxyTCPClientHandler) processFrames(frameBuffer *[]byte, dst net.Conn, direction string) {
+	for len(*frameBuffer) > 0 {
+		frame := make([]byte, 0)
+		h.rtuPackager.TryDecode(frameBuffer, &frame)
+		if len(frame) == 0 {
+			break
+		}
+
+		// Write the complete frame to the destination
+		_, err := dst.Write(frame)
+		if err != nil {
+			log.Error("Error writing complete frame", "direction", direction, "error", err)
+			return
+		}
+	}
+}

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -45,10 +45,11 @@ type rtuPackager struct {
 }
 
 // Encode encodes PDU in a RTU frame:
-//  Slave Address   : 1 byte
-//  Function        : 1 byte
-//  Data            : 0 up to 252 bytes
-//  CRC             : 2 byte
+//
+//	Slave Address   : 1 byte
+//	Function        : 1 byte
+//	Data            : 0 up to 252 bytes
+//	CRC             : 2 byte
 func (mb *rtuPackager) Encode(pdu *ProtocolDataUnit) (adu []byte, err error) {
 	length := len(pdu.Data) + 4
 	if length > rtuMaxSize {
@@ -103,6 +104,99 @@ func (mb *rtuPackager) Decode(adu []byte) (pdu *ProtocolDataUnit, err error) {
 	pdu.FunctionCode = adu[1]
 	pdu.Data = adu[2 : length-2]
 	return
+}
+
+func (mb *rtuPackager) TryDecode(buffer *[]byte, frame *[]byte) {
+
+	// Check if we have enough data for a complete frame
+	frameLength := mb.findFrameInBuffer(*buffer)
+	if frameLength == 0 {
+		// Not enough data for a complete frame
+		return
+	}
+
+	if len(*buffer) < frameLength {
+		// Not enough data for complete frame
+		return
+	}
+
+	// Extract complete frame
+	*frame = (*buffer)[:frameLength]
+	*buffer = (*buffer)[frameLength:]
+}
+
+func (mb *rtuPackager) findFrameInBuffer(data []byte) int {
+	if len(data) < 2 {
+		return 0
+	}
+	// For RTU over TCP, the frame structure is:
+	// [Slave ID][Function Code][Data...][CRC Low][CRC High]
+
+	_ = data[0] // slaveID
+	functionCode := data[1]
+
+	// Calculate expected frame length based on function code
+	var expectedLength int
+
+	switch functionCode {
+	case 0x01, 0x02, 0x03, 0x04, 0x05, 0x06:
+		// Read/Write single register/coil functions
+		// [Slave ID][Function Code][Address High][Address Low][Value High][Value Low][CRC Low][CRC High]
+		expectedLength = 8
+	case 0x0F, 0x10:
+		// Write multiple registers/coils
+		// [Slave ID][Function Code][Address High][Address Low][Quantity High][Quantity Low][Byte Count][Data...][CRC Low][CRC High]
+		if len(data) < 6 {
+			return 0 // Need at least 6 bytes to determine length
+		}
+		byteCount := int(data[6])
+		expectedLength = 9 + byteCount // 7 header bytes + data + 2 CRC bytes
+	case 0x17:
+		// Read/Write Multiple Registers
+		// [Slave ID][Function Code][Read Address High][Read Address Low][Read Quantity High][Read Quantity Low][Write Address High][Write Address Low][Write Quantity High][Write Quantity Low][Write Byte Count][Write Data...][CRC Low][CRC High]
+		if len(data) < 12 {
+			return 0 // Need at least 12 bytes to determine length
+		}
+		writeByteCount := int(data[11])
+		expectedLength = 13 + writeByteCount // 12 header bytes + data + 2 CRC bytes
+	default:
+		// For unknown function codes, try to find frame boundary by looking for valid CRC
+		// This is a fallback method
+		return mb.findFrameByCRC(data)
+	}
+
+	// Check if we have enough data for the expected frame length
+	if len(data) >= expectedLength {
+		return expectedLength
+	}
+
+	return 0 // Not enough data for complete frame
+}
+
+func (mb *rtuPackager) findFrameByCRC(data []byte) int {
+	// Try to find frame boundary by validating CRC
+	// This is a fallback for unknown function codes
+	for i := 4; i <= len(data)-2; i++ {
+		if mb.validateCRC(data[:i+2]) {
+			return i + 2
+		}
+	}
+	return 0
+}
+
+func (mb *rtuPackager) validateCRC(data []byte) bool {
+	if len(data) < 3 {
+		return false
+	}
+
+	// Extract CRC from last 2 bytes
+	crcReceived := uint16(data[len(data)-2]) | (uint16(data[len(data)-1]) << 8)
+
+	// Calculate CRC for data without the CRC bytes
+	var crc crc
+	crc.reset().pushBytes(data[:len(data)-2])
+	return crcReceived == crc.value()
+
 }
 
 // rtuSerialTransporter implements Transporter interface.

--- a/tcpclient.go
+++ b/tcpclient.go
@@ -94,12 +94,13 @@ type tcpPackager struct {
 }
 
 // Encode adds modbus application protocol header:
-//  Transaction identifier: 2 bytes
-//  Protocol identifier: 2 bytes
-//  Length: 2 bytes
-//  Unit identifier: 1 byte
-//  Function code: 1 byte
-//  Data: n bytes
+//
+//	Transaction identifier: 2 bytes
+//	Protocol identifier: 2 bytes
+//	Length: 2 bytes
+//	Unit identifier: 1 byte
+//	Function code: 1 byte
+//	Data: n bytes
 func (mb *tcpPackager) Encode(pdu *ProtocolDataUnit) (adu []byte, err error) {
 	adu = make([]byte, tcpHeaderSize+1+len(pdu.Data))
 
@@ -154,10 +155,11 @@ func (mb *tcpPackager) Verify(aduRequest []byte, aduResponse []byte) (err error)
 }
 
 // Decode extracts PDU from TCP frame:
-//  Transaction identifier: 2 bytes
-//  Protocol identifier: 2 bytes
-//  Length: 2 bytes
-//  Unit identifier: 1 byte
+//
+//	Transaction identifier: 2 bytes
+//	Protocol identifier: 2 bytes
+//	Length: 2 bytes
+//	Unit identifier: 1 byte
 func (mb *tcpPackager) Decode(adu []byte) (pdu *ProtocolDataUnit, err error) {
 	// Read length value in the header
 	length := binary.BigEndian.Uint16(adu[4:])


### PR DESCRIPTION
This commit adds a new ProxyTCPClientHandler that facilitates TCP proxying for Modbus communication. It manages connections, forwards data between local and remote endpoints, and handles frame reassembly. The implementation includes methods for starting the proxy, sending requests, and closing connections, enhancing the existing TCP client functionality.