### PR TITLE
Enhance Modbus TCP decoding and testing

### DIFF
--- a/tcpclient.go
+++ b/tcpclient.go
@@ -160,19 +160,33 @@ func (mb *tcpPackager) Verify(aduRequest []byte, aduResponse []byte) (err error)
 //	Protocol identifier: 2 bytes
 //	Length: 2 bytes
 //	Unit identifier: 1 byte
+//
+// Validation is relaxed to accept real-world captures: the frame must have at least
+// unit ID + function code (2 bytes after header), and at least as many bytes as the
+// MBAP length field indicates. Extra trailing bytes are allowed (e.g. padding).
 func (mb *tcpPackager) Decode(adu []byte) (pdu *ProtocolDataUnit, err error) {
-	// Read length value in the header
-	length := binary.BigEndian.Uint16(adu[4:])
 	pduLength := len(adu) - tcpHeaderSize
-	if pduLength <= 0 || pduLength != int(length-1) {
-		return pdu, &ModbusTCPError{
+	if len(adu) < tcpHeaderSize+2 {
+		resp := pduLength
+		if resp < 0 {
+			resp = 0
+		}
+		return nil, &ModbusTCPError{
+			ExceptionCode: ExceptionCodeWrongSize,
+			Request:       2,
+			Response:      resp,
+		}
+	}
+	length := binary.BigEndian.Uint16(adu[4:])
+	// Require at least unit ID + function code; require at least as many bytes as header says (no truncation)
+	if pduLength < 2 || pduLength < int(length-1) {
+		return nil, &ModbusTCPError{
 			ExceptionCode: ExceptionCodeWrongSize,
 			Request:       length - 1,
 			Response:      pduLength,
 		}
 	}
 	pdu = &ProtocolDataUnit{}
-	// The first byte after header is function code
 	pdu.FunctionCode = adu[tcpHeaderSize]
 	pdu.Data = adu[tcpHeaderSize+1:]
 	return

--- a/tcpdecode.go
+++ b/tcpdecode.go
@@ -1,0 +1,61 @@
+package modbus
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// TCPHeaderSize is the size of the Modbus TCP MBAP header in bytes.
+//
+// MBAP header:
+//   - Transaction identifier: 2 bytes
+//   - Protocol identifier: 2 bytes
+//   - Length: 2 bytes
+//   - Unit identifier: 1 byte
+const TCPHeaderSize = tcpHeaderSize
+
+// TCPFrame contains the decoded Modbus TCP MBAP header fields and PDU.
+type TCPFrame struct {
+	TransactionID uint16
+	ProtocolID    uint16
+	// Length is the MBAP length field (bytes following: UnitID + PDU).
+	Length uint16
+	UnitID byte
+	PDU    *ProtocolDataUnit
+}
+
+// DecodeTCP decodes a Modbus TCP ADU into MBAP header fields and PDU.
+//
+// Validation is relaxed to accept real-world captures: the frame must have at least
+// unit ID + function code, and at least as many bytes as the MBAP length field indicates.
+// Extra trailing bytes (e.g. padding) are allowed.
+func DecodeTCP(adu []byte) (*TCPFrame, error) {
+	// Need at least MBAP header + function code.
+	if len(adu) < tcpHeaderSize+1 {
+		return nil, fmt.Errorf("modbus: tcp adu too short: %d", len(adu))
+	}
+
+	pdu, err := (&tcpPackager{}).Decode(adu)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TCPFrame{
+		TransactionID: binary.BigEndian.Uint16(adu[0:2]),
+		ProtocolID:    binary.BigEndian.Uint16(adu[2:4]),
+		Length:        binary.BigEndian.Uint16(adu[4:6]),
+		UnitID:        adu[6],
+		PDU:           pdu,
+	}, nil
+}
+
+// DecodePDUFromTCP extracts the PDU from a Modbus TCP ADU.
+// For MBAP header fields, use DecodeTCP.
+func DecodePDUFromTCP(adu []byte) (*ProtocolDataUnit, error) {
+	frame, err := DecodeTCP(adu)
+	if err != nil {
+		return nil, err
+	}
+	return frame.PDU, nil
+}
+

--- a/tcpdecode_test.go
+++ b/tcpdecode_test.go
@@ -1,0 +1,88 @@
+package modbus
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestDecodeTCP(t *testing.T) {
+	adu := []byte{0, 1, 0, 0, 0, 6, 17, 3, 0, 120, 0, 3}
+
+	frame, err := DecodeTCP(adu)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if frame.TransactionID != 1 {
+		t.Fatalf("TransactionID: expected %v, got %v", 1, frame.TransactionID)
+	}
+	if frame.ProtocolID != 0 {
+		t.Fatalf("ProtocolID: expected %v, got %v", 0, frame.ProtocolID)
+	}
+	if frame.Length != 6 {
+		t.Fatalf("Length: expected %v, got %v", 6, frame.Length)
+	}
+	if frame.UnitID != 17 {
+		t.Fatalf("UnitID: expected %v, got %v", 17, frame.UnitID)
+	}
+	if frame.PDU == nil {
+		t.Fatalf("PDU: expected non-nil")
+	}
+	if frame.PDU.FunctionCode != 3 {
+		t.Fatalf("FunctionCode: expected %v, got %v", 3, frame.PDU.FunctionCode)
+	}
+	expected := []byte{0, 120, 0, 3}
+	if !bytes.Equal(expected, frame.PDU.Data) {
+		t.Fatalf("Data: expected %v, got %v", expected, frame.PDU.Data)
+	}
+}
+
+func TestDecodeTCPTooShort(t *testing.T) {
+	// Less than MBAP header + function code (7 + 1).
+	_, err := DecodeTCP([]byte{0, 1, 0, 0, 0, 6, 17})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestDecodeTCPTruncated(t *testing.T) {
+	// Header says length=7 (6 bytes after header), but we only have 5 bytes (truncated).
+	adu := []byte{0, 1, 0, 0, 0, 7, 17, 3, 0, 120, 0}
+	_, err := DecodeTCP(adu)
+	if err == nil {
+		t.Fatalf("expected error for truncated frame")
+	}
+}
+
+func TestDecodeTCPRelaxedExtraBytes(t *testing.T) {
+	// Real-world case: 260 bytes total, MBAP length=253 (252 bytes PDU after unit ID).
+	// Strict decode would reject (253 != 252); relaxed decode accepts and uses actual buffer.
+	adu := make([]byte, 260)
+	adu[0], adu[1] = 0x37, 0x4e // transaction ID
+	adu[2], adu[3] = 0, 0        // protocol ID
+	adu[4], adu[5] = 0, 253      // length = 253 (unit ID + 252 bytes PDU)
+	adu[6] = 1                   // unit ID
+	adu[7] = 0x10                // function code (Write Multiple Registers)
+	copy(adu[8:], bytes.Repeat([]byte{0xff}, 252))
+
+	frame, err := DecodeTCP(adu)
+	if err != nil {
+		t.Fatalf("relaxed decode should accept frame with extra byte: %v", err)
+	}
+	if frame.TransactionID != 0x374e {
+		t.Fatalf("TransactionID: expected 0x374e, got %v", frame.TransactionID)
+	}
+	if frame.Length != 253 {
+		t.Fatalf("Length: expected 253, got %v", frame.Length)
+	}
+	if frame.UnitID != 1 {
+		t.Fatalf("UnitID: expected 1, got %v", frame.UnitID)
+	}
+	if frame.PDU.FunctionCode != 0x10 {
+		t.Fatalf("FunctionCode: expected 0x10, got %v", frame.PDU.FunctionCode)
+	}
+	if len(frame.PDU.Data) != 252 {
+		t.Fatalf("PDU data length: expected 252, got %v", len(frame.PDU.Data))
+	}
+}
+


### PR DESCRIPTION
- Updated the Decode function in tcpPackager to relax validation, allowing for captures with extra trailing bytes.
- Introduced a new DecodeTCP function to handle Modbus TCP ADUs, including improved error handling for short and truncated frames.
- Added comprehensive unit tests for DecodeTCP, covering various scenarios including valid frames, too short frames, and relaxed decoding with extra bytes.